### PR TITLE
Cutscene rework

### DIFF
--- a/Project/core/DebugManager.cs
+++ b/Project/core/DebugManager.cs
@@ -306,7 +306,7 @@ namespace Project.Core
 			if (!IsInstanceValid(StageSettings.instance) || !IsInstanceValid(CharacterController.instance)) return;
 			if (customCheckpoint == null)
 			{
-				GD.PrintErr("No custom checkpoint.");
+				GD.PushWarning("No custom checkpoint.");
 				return;
 			}
 

--- a/Project/interface/boot/Boot.tscn
+++ b/Project/interface/boot/Boot.tscn
@@ -2,8 +2,8 @@
 
 [ext_resource type="Script" path="res://interface/boot/Boot.cs" id="1_c3660"]
 [ext_resource type="AudioStream" uid="uid://c2y53tq5h1b76" path="res://video/boot/logo.wav" id="2_81oeg"]
+[ext_resource type="Script" path="res://video/VideoStreamFileLoadPlayer.cs" id="2_bf4bq"]
 [ext_resource type="FontFile" uid="uid://dakokhex1lp8k" path="res://interface/font/otf/Greco Std B.otf" id="2_eryyg"]
-[ext_resource type="VideoStream" path="res://video/boot/logo en.ogv" id="2_remjm"]
 
 [sub_resource type="QuadMesh" id="QuadMesh_qptrl"]
 
@@ -218,8 +218,9 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
-stream = ExtResource("2_remjm")
 expand = true
+script = ExtResource("2_bf4bq")
+videoFilePath = "res://video/boot/logo en.ogv"
 
 [node name="Original" type="Label" parent="Logo"]
 visible = false

--- a/Project/interface/menu/level select/script/WorldSelect.cs
+++ b/Project/interface/menu/level select/script/WorldSelect.cs
@@ -78,7 +78,15 @@ namespace Project.Interface.Menus
 		private void LoadVideos()
 		{
 			for (int i = 0; i < videoStreams.Length; i++)
-				videoStreams[i] = ResourceLoader.Load<VideoStream>(videoStreamPaths[i]);
+			{
+				if (ResourceLoader.Exists(videoStreamPaths[i], "VideoStream"))
+				{
+					videoStreams[i] = ResourceLoader.Load<VideoStream>(videoStreamPaths[i]);
+					continue;
+				}
+
+				GD.PushWarning($"Couldn't find video {videoStreams[i]}!");
+			}
 		}
 
 

--- a/Project/interface/menu/title/Title.cs
+++ b/Project/interface/menu/title/Title.cs
@@ -15,7 +15,6 @@ namespace Project.Interface.Menus
 		private float cutsceneTimer;
 		private const float CUTSCENE_TIME_LENGTH = 20f;
 
-
 		protected override void SetUp()
 		{
 			isProcessing = menuMemory[MemoryKeys.ActiveMenu] == (int)MemoryKeys.Title;

--- a/Project/interface/menu/title/Title.tscn
+++ b/Project/interface/menu/title/Title.tscn
@@ -1,7 +1,6 @@
 [gd_scene load_steps=51 format=3 uid="uid://cbamk7p3d1ddn"]
 
 [ext_resource type="Texture2D" uid="uid://chvedyxbnb0fh" path="res://interface/menu/title/texture/logos/logo en.png" id="1"]
-[ext_resource type="VideoStream" path="res://video/event/stream/event0.ogv" id="2"]
 [ext_resource type="AudioStream" uid="uid://crnh8q3fup5o7" path="res://video/event/opening.ogg" id="4"]
 [ext_resource type="Texture2D" uid="uid://cmg0230lkyvho" path="res://interface/menu/title/texture/transition/tile018.png" id="8"]
 [ext_resource type="Texture2D" uid="uid://c6siw4cmrwyv8" path="res://interface/menu/title/texture/transition/tile011.png" id="9"]
@@ -38,6 +37,7 @@
 [ext_resource type="PackedScene" uid="uid://dad2hh4ttgaox" path="res://interface/menu/flames/Flames.tscn" id="33_hglwt"]
 [ext_resource type="AudioStream" uid="uid://cruu5h1jr78lr" path="res://sound/sfx/system/menu screen change.wav" id="34_nycgp"]
 [ext_resource type="Script" path="res://interface/menu/title/Title.cs" id="35"]
+[ext_resource type="Script" path="res://video/VideoStreamFileLoadPlayer.cs" id="36_2rss8"]
 
 [sub_resource type="SpriteFrames" id="11"]
 animations = [{
@@ -1182,9 +1182,9 @@ color = Color(0, 0, 0, 1)
 layout_mode = 0
 offset_right = 1920.0
 offset_bottom = 1080.0
-stream = ExtResource("2")
 expand = true
-buffering_msec = 10
+script = ExtResource("36_2rss8")
+videoFilePath = "res://video/event/stream/event0.ogv"
 
 [node name="CutsceneAudio" type="AudioStreamPlayer" parent="Cutscene"]
 stream = ExtResource("4")

--- a/Project/object/player/resource/script/CharacterEffect.cs
+++ b/Project/object/player/resource/script/CharacterEffect.cs
@@ -260,7 +260,7 @@ namespace Project.Gameplay
 
 			if (groundKeyIndex != 0) // Avoid being spammed with warnings
 			{
-				GD.PrintErr($"'{collision.Name}' isn't in any sound groups found in CharacterSound.cs.");
+				GD.PushWarning($"'{collision.Name}' isn't in any sound groups found in CharacterSound.cs.");
 				groundKeyIndex = 0; // Default to first key (pavement)
 			}
 		}

--- a/Project/resource/script/SFXLibraryResource.cs
+++ b/Project/resource/script/SFXLibraryResource.cs
@@ -136,9 +136,9 @@ namespace Project.Gameplay
 			for (int i = 0; i < KeyCount; i++)
 			{
 				if (string.IsNullOrEmpty(keys[i]))
-					GD.PrintErr($"Warning! Voice Key '{i}' is empty.");
+					GD.PushWarning($"Voice Key '{i}' is empty.");
 				else if (duplicateKeyChecker.Contains(keys[i]))
-					GD.PrintErr($"Warning! Voice Key '{keys[i]}' (Index {i}) is a duplicate.");
+					GD.PushWarning($"Voice Key '{keys[i]}' (Index {i}) is a duplicate.");
 				else
 					duplicateKeyChecker.Add(keys[i]);
 			}

--- a/Project/sound/script/SoundManager.cs
+++ b/Project/sound/script/SoundManager.cs
@@ -140,7 +140,7 @@ namespace Project.Core
 			{
 				if (!currentDialog.HasLength(currentDialogIndex)) // Skip
 				{
-					GD.PrintErr("Text-only dialog doesn't have a specified length. Skipping.");
+					GD.PushWarning("Text-only dialog doesn't have a specified length. Skipping.");
 					OnDialogFinished();
 					return;
 				}

--- a/Project/video/Event.tscn
+++ b/Project/video/Event.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=2 format=3 uid="uid://ct1tmuno23lj2"]
+[gd_scene load_steps=3 format=3 uid="uid://ct1tmuno23lj2"]
 
 [ext_resource type="Script" path="res://video/EventPlayer.cs" id="1"]
+[ext_resource type="Script" path="res://video/VideoStreamFileLoadPlayer.cs" id="2_k3sn5"]
 
 [node name="Event" type="CanvasLayer" node_paths=PackedStringArray("audioPlayer", "videoPlayer")]
 script = ExtResource("1")
@@ -14,6 +15,7 @@ autoplay = true
 offset_right = 1920.0
 offset_bottom = 1080.0
 expand = true
+script = ExtResource("2_k3sn5")
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]
 

--- a/Project/video/VideoStreamFileLoadPlayer.cs
+++ b/Project/video/VideoStreamFileLoadPlayer.cs
@@ -1,0 +1,21 @@
+using Godot;
+
+namespace Project.Interface.Menus
+{
+	public partial class VideoStreamFileLoadPlayer : VideoStreamPlayer
+	{
+		[Export(PropertyHint.File)]
+		private string videoFilePath;
+
+		public override void _Ready()
+		{
+			if (!ResourceLoader.Exists(videoFilePath, "VideoStreamTheora"))
+			{
+				GD.PushWarning($"Couldn't load video file {videoFilePath}!");
+				return;
+			}
+
+			Stream = ResourceLoader.Load<VideoStreamTheora>(videoFilePath, "VideoStreamTheora");
+		}
+	}
+}

--- a/Project/video/event/scene/Event1.tscn
+++ b/Project/video/event/scene/Event1.tscn
@@ -1,8 +1,7 @@
-[gd_scene load_steps=5 format=3 uid="uid://j3qfvyr8oosj"]
+[gd_scene load_steps=4 format=3 uid="uid://j3qfvyr8oosj"]
 
 [ext_resource type="PackedScene" uid="uid://ct1tmuno23lj2" path="res://video/Event.tscn" id="1"]
 [ext_resource type="AudioStream" uid="uid://lm7dx7el68a5" path="res://video/event/ja/event1.ogg" id="2"]
-[ext_resource type="VideoStream" path="res://video/event/stream/event1.ogv" id="3"]
 [ext_resource type="AudioStream" uid="uid://djunftue4v4bf" path="res://video/event/en/event1.ogg" id="4"]
 
 [node name="Event" instance=ExtResource("1")]
@@ -80,8 +79,5 @@ event01_69	250.3	2.5	-1	-1
 event01_70	253.7	0.1	-1	-1
 event01_71	256.4	2.4	-1	-1"
 
-[node name="Audio" parent="." index="0"]
-bus = &"Master"
-
 [node name="Video" parent="." index="1"]
-stream = ExtResource("3")
+videoFilePath = "res://video/event/stream/event1.ogv"

--- a/Project/video/event/scene/Event10.tscn
+++ b/Project/video/event/scene/Event10.tscn
@@ -1,7 +1,6 @@
-[gd_scene load_steps=5 format=3 uid="uid://dt2irybq37abg"]
+[gd_scene load_steps=4 format=3 uid="uid://dt2irybq37abg"]
 
 [ext_resource type="PackedScene" uid="uid://ct1tmuno23lj2" path="res://video/Event.tscn" id="1"]
-[ext_resource type="VideoStream" path="res://video/event/stream/event10.ogv" id="2"]
 [ext_resource type="AudioStream" uid="uid://bh2klryhskj5s" path="res://video/event/ja/event10.ogg" id="3"]
 [ext_resource type="AudioStream" uid="uid://gngbj1l4do0n" path="res://video/event/en/event10.ogg" id="4"]
 
@@ -81,5 +80,5 @@ event01_69	250.3	2.5	-1	-1
 event01_70	253.7	0.1	-1	-1
 event01_71	256.4	2.4	-1	-1"
 
-[node name="Video" parent="." index="0"]
-stream = ExtResource("2")
+[node name="Video" parent="." index="1"]
+videoFilePath = "res://video/event/stream/event10.ogv"

--- a/Project/video/event/scene/Event11.tscn
+++ b/Project/video/event/scene/Event11.tscn
@@ -1,7 +1,6 @@
-[gd_scene load_steps=5 format=3 uid="uid://67f74wj5nkhq"]
+[gd_scene load_steps=4 format=3 uid="uid://67f74wj5nkhq"]
 
 [ext_resource type="PackedScene" uid="uid://ct1tmuno23lj2" path="res://video/Event.tscn" id="1"]
-[ext_resource type="VideoStream" path="res://video/event/stream/event11.ogv" id="2"]
 [ext_resource type="AudioStream" uid="uid://bt0khcve6ibhd" path="res://video/event/ja/event11.ogg" id="3"]
 [ext_resource type="AudioStream" uid="uid://c0e5cs44wc0io" path="res://video/event/en/event11.ogg" id="4"]
 
@@ -81,5 +80,5 @@ event01_69	250.3	2.5	-1	-1
 event01_70	253.7	0.1	-1	-1
 event01_71	256.4	2.4	-1	-1"
 
-[node name="Video" parent="." index="0"]
-stream = ExtResource("2")
+[node name="Video" parent="." index="1"]
+videoFilePath = "res://video/event/stream/event11.ogv"

--- a/Project/video/event/scene/Event12.tscn
+++ b/Project/video/event/scene/Event12.tscn
@@ -1,7 +1,6 @@
-[gd_scene load_steps=5 format=3 uid="uid://c34pbto7enje7"]
+[gd_scene load_steps=4 format=3 uid="uid://c34pbto7enje7"]
 
 [ext_resource type="PackedScene" uid="uid://ct1tmuno23lj2" path="res://video/Event.tscn" id="1"]
-[ext_resource type="VideoStream" path="res://video/event/stream/event12.ogv" id="2"]
 [ext_resource type="AudioStream" uid="uid://cj6c4tphgmosl" path="res://video/event/ja/event12.ogg" id="3"]
 [ext_resource type="AudioStream" uid="uid://b8wxr2swm42k7" path="res://video/event/en/event12.ogg" id="4"]
 
@@ -81,5 +80,5 @@ event01_69	250.3	2.5	-1	-1
 event01_70	253.7	0.1	-1	-1
 event01_71	256.4	2.4	-1	-1"
 
-[node name="Video" parent="." index="0"]
-stream = ExtResource("2")
+[node name="Video" parent="." index="1"]
+videoFilePath = "res://video/event/stream/event12.ogv"

--- a/Project/video/event/scene/Event13.tscn
+++ b/Project/video/event/scene/Event13.tscn
@@ -1,7 +1,6 @@
-[gd_scene load_steps=5 format=3 uid="uid://bq8yi0wuokqrh"]
+[gd_scene load_steps=4 format=3 uid="uid://bq8yi0wuokqrh"]
 
 [ext_resource type="PackedScene" uid="uid://ct1tmuno23lj2" path="res://video/Event.tscn" id="1"]
-[ext_resource type="VideoStream" path="res://video/event/stream/event13.ogv" id="2"]
 [ext_resource type="AudioStream" uid="uid://beo3k3i1av3sh" path="res://video/event/ja/event13.ogg" id="3"]
 [ext_resource type="AudioStream" uid="uid://b5n8xeu84e8qc" path="res://video/event/en/event13.ogg" id="4"]
 
@@ -81,5 +80,5 @@ event01_69	250.3	2.5	-1	-1
 event01_70	253.7	0.1	-1	-1
 event01_71	256.4	2.4	-1	-1"
 
-[node name="Video" parent="." index="0"]
-stream = ExtResource("2")
+[node name="Video" parent="." index="1"]
+videoFilePath = "res://video/event/stream/event13.ogv"

--- a/Project/video/event/scene/Event14.tscn
+++ b/Project/video/event/scene/Event14.tscn
@@ -1,7 +1,6 @@
-[gd_scene load_steps=5 format=3 uid="uid://bviuewois4a6m"]
+[gd_scene load_steps=4 format=3 uid="uid://bviuewois4a6m"]
 
 [ext_resource type="PackedScene" uid="uid://ct1tmuno23lj2" path="res://video/Event.tscn" id="1"]
-[ext_resource type="VideoStream" path="res://video/event/stream/event14.ogv" id="2"]
 [ext_resource type="AudioStream" uid="uid://dunc0q0hbvbak" path="res://video/event/ja/event14.ogg" id="3"]
 [ext_resource type="AudioStream" uid="uid://dhd2qn7jygvwt" path="res://video/event/en/event14.ogg" id="4"]
 
@@ -81,5 +80,5 @@ event01_69	250.3	2.5	-1	-1
 event01_70	253.7	0.1	-1	-1
 event01_71	256.4	2.4	-1	-1"
 
-[node name="Video" parent="." index="0"]
-stream = ExtResource("2")
+[node name="Video" parent="." index="1"]
+videoFilePath = "res://video/event/stream/event14.ogv"

--- a/Project/video/event/scene/Event15.tscn
+++ b/Project/video/event/scene/Event15.tscn
@@ -1,7 +1,6 @@
-[gd_scene load_steps=5 format=3 uid="uid://qx4032f526e3"]
+[gd_scene load_steps=4 format=3 uid="uid://qx4032f526e3"]
 
 [ext_resource type="PackedScene" uid="uid://ct1tmuno23lj2" path="res://video/Event.tscn" id="1"]
-[ext_resource type="VideoStream" path="res://video/event/stream/event15.ogv" id="2"]
 [ext_resource type="AudioStream" uid="uid://h8rvuis2nmug" path="res://video/event/ja/event15.ogg" id="3"]
 [ext_resource type="AudioStream" uid="uid://4sg1epytsi6a" path="res://video/event/en/event15.ogg" id="4"]
 
@@ -81,5 +80,5 @@ event01_69	250.3	2.5	-1	-1
 event01_70	253.7	0.1	-1	-1
 event01_71	256.4	2.4	-1	-1"
 
-[node name="Video" parent="." index="0"]
-stream = ExtResource("2")
+[node name="Video" parent="." index="1"]
+videoFilePath = "res://video/event/stream/event15.ogv"

--- a/Project/video/event/scene/Event16.tscn
+++ b/Project/video/event/scene/Event16.tscn
@@ -1,7 +1,6 @@
-[gd_scene load_steps=5 format=3 uid="uid://ivxax0odni6n"]
+[gd_scene load_steps=4 format=3 uid="uid://ivxax0odni6n"]
 
 [ext_resource type="PackedScene" uid="uid://ct1tmuno23lj2" path="res://video/Event.tscn" id="1"]
-[ext_resource type="VideoStream" path="res://video/event/stream/event16.ogv" id="2"]
 [ext_resource type="AudioStream" uid="uid://cca20rttp6wu2" path="res://video/event/ja/event16.ogg" id="3"]
 [ext_resource type="AudioStream" uid="uid://berd0ykfxa135" path="res://video/event/en/event16.ogg" id="4"]
 
@@ -81,5 +80,5 @@ event01_69	250.3	2.5	-1	-1
 event01_70	253.7	0.1	-1	-1
 event01_71	256.4	2.4	-1	-1"
 
-[node name="Video" parent="." index="0"]
-stream = ExtResource("2")
+[node name="Video" parent="." index="1"]
+videoFilePath = "res://video/event/stream/event16.ogv"

--- a/Project/video/event/scene/Event17.tscn
+++ b/Project/video/event/scene/Event17.tscn
@@ -1,7 +1,6 @@
-[gd_scene load_steps=5 format=3 uid="uid://bpt7dtu7lh4xp"]
+[gd_scene load_steps=4 format=3 uid="uid://bpt7dtu7lh4xp"]
 
 [ext_resource type="PackedScene" uid="uid://ct1tmuno23lj2" path="res://video/Event.tscn" id="1"]
-[ext_resource type="VideoStream" path="res://video/event/stream/event17.ogv" id="2"]
 [ext_resource type="AudioStream" uid="uid://cxsy1ur86emvw" path="res://video/event/ja/event17.ogg" id="3"]
 [ext_resource type="AudioStream" uid="uid://dwaoufsbauwno" path="res://video/event/en/event17.ogg" id="4"]
 
@@ -81,5 +80,5 @@ event01_69	250.3	2.5	-1	-1
 event01_70	253.7	0.1	-1	-1
 event01_71	256.4	2.4	-1	-1"
 
-[node name="Video" parent="." index="0"]
-stream = ExtResource("2")
+[node name="Video" parent="." index="1"]
+videoFilePath = "res://video/event/stream/event17.ogv"

--- a/Project/video/event/scene/Event18.tscn
+++ b/Project/video/event/scene/Event18.tscn
@@ -1,7 +1,6 @@
-[gd_scene load_steps=5 format=3 uid="uid://cf6iukh4vpv0"]
+[gd_scene load_steps=4 format=3 uid="uid://cf6iukh4vpv0"]
 
 [ext_resource type="PackedScene" uid="uid://ct1tmuno23lj2" path="res://video/Event.tscn" id="1"]
-[ext_resource type="VideoStream" path="res://video/event/stream/event18.ogv" id="2"]
 [ext_resource type="AudioStream" uid="uid://cnpv1lq2dx2i4" path="res://video/event/ja/event18.ogg" id="3"]
 [ext_resource type="AudioStream" uid="uid://dj8q3piqktmh8" path="res://video/event/en/event18.ogg" id="4"]
 
@@ -81,5 +80,5 @@ event01_69	250.3	2.5	-1	-1
 event01_70	253.7	0.1	-1	-1
 event01_71	256.4	2.4	-1	-1"
 
-[node name="Video" parent="." index="0"]
-stream = ExtResource("2")
+[node name="Video" parent="." index="1"]
+videoFilePath = "res://video/event/stream/event18.ogv"

--- a/Project/video/event/scene/Event19.tscn
+++ b/Project/video/event/scene/Event19.tscn
@@ -1,8 +1,7 @@
-[gd_scene load_steps=5 format=3 uid="uid://b2vn42lm0lhdv"]
+[gd_scene load_steps=4 format=3 uid="uid://b2vn42lm0lhdv"]
 
 [ext_resource type="PackedScene" uid="uid://ct1tmuno23lj2" path="res://video/Event.tscn" id="1"]
 [ext_resource type="AudioStream" uid="uid://br2i1me61oteb" path="res://video/event/ja/event19.ogg" id="2"]
-[ext_resource type="VideoStream" path="res://video/event/stream/event19.ogv" id="3"]
 [ext_resource type="AudioStream" uid="uid://y50vv2lf06ql" path="res://video/event/en/event19.ogg" id="4"]
 
 [node name="Event" instance=ExtResource("1")]
@@ -81,5 +80,5 @@ event01_69	250.3	2.5	-1	-1
 event01_70	253.7	0.1	-1	-1
 event01_71	256.4	2.4	-1	-1"
 
-[node name="Video" parent="." index="0"]
-stream = ExtResource("3")
+[node name="Video" parent="." index="1"]
+videoFilePath = "res://video/event/stream/event19.ogv"

--- a/Project/video/event/scene/Event2.tscn
+++ b/Project/video/event/scene/Event2.tscn
@@ -1,15 +1,13 @@
-[gd_scene load_steps=5 format=3 uid="uid://bnwwioqxebjw0"]
+[gd_scene load_steps=4 format=3 uid="uid://bnwwioqxebjw0"]
 
 [ext_resource type="PackedScene" uid="uid://ct1tmuno23lj2" path="res://video/Event.tscn" id="1"]
 [ext_resource type="AudioStream" uid="uid://ch8m303mddmtu" path="res://video/event/ja/event2.ogg" id="2"]
 [ext_resource type="AudioStream" uid="uid://bajmkt1dtww8c" path="res://video/event/en/event2.ogg" id="3"]
-[ext_resource type="VideoStream" path="res://video/event/stream/event2.ogv" id="4"]
 
 [node name="Event" instance=ExtResource("1")]
 enAudio = ExtResource("3")
 jaAudio = ExtResource("2")
-subtitleData = "Key	Start	Spacing	JP Start	JP Spacing
-event01_1	4	0.05	-1	-1
+subtitleData = "event01_1	4	0.05	-1	-1
 event01_2	6.5	0.05	-1	-1
 event01_3	7.64	0.05	-1	-1
 event01_4	10	0.05	-1	-1
@@ -81,5 +79,5 @@ event01_69	250.3	2.5	-1	-1
 event01_70	253.7	0.1	-1	-1
 event01_71	256.4	2.4	-1	-1"
 
-[node name="Video" parent="." index="0"]
-stream = ExtResource("4")
+[node name="Video" parent="." index="1"]
+videoFilePath = "res://video/event/stream/event2.ogv"

--- a/Project/video/event/scene/Event20.tscn
+++ b/Project/video/event/scene/Event20.tscn
@@ -1,8 +1,7 @@
-[gd_scene load_steps=5 format=3 uid="uid://b3w1owi4fevt0"]
+[gd_scene load_steps=4 format=3 uid="uid://b3w1owi4fevt0"]
 
 [ext_resource type="PackedScene" uid="uid://ct1tmuno23lj2" path="res://video/Event.tscn" id="1"]
 [ext_resource type="AudioStream" uid="uid://rvmrp6xafwnm" path="res://video/event/ja/event20.ogg" id="2"]
-[ext_resource type="VideoStream" path="res://video/event/stream/event20.ogv" id="3"]
 [ext_resource type="AudioStream" uid="uid://ccq8psn21llra" path="res://video/event/en/event20.ogg" id="4"]
 
 [node name="Event" instance=ExtResource("1")]
@@ -25,8 +24,5 @@ event20_14	41.4	0.05	39.9	-1
 event20_15	43	0.05	41.2	-1
 event20_16	47.6	2	-1	-1"
 
-[node name="Audio" parent="." index="0"]
-bus = &"Master"
-
 [node name="Video" parent="." index="1"]
-stream = ExtResource("3")
+videoFilePath = "res://video/event/stream/event20.ogv"

--- a/Project/video/event/scene/Event21.tscn
+++ b/Project/video/event/scene/Event21.tscn
@@ -1,8 +1,7 @@
-[gd_scene load_steps=5 format=3 uid="uid://bihhhh75e6hi7"]
+[gd_scene load_steps=4 format=3 uid="uid://bihhhh75e6hi7"]
 
 [ext_resource type="PackedScene" uid="uid://ct1tmuno23lj2" path="res://video/Event.tscn" id="1"]
 [ext_resource type="AudioStream" uid="uid://dwrgpimuunee2" path="res://video/event/ja/event21.ogg" id="2"]
-[ext_resource type="VideoStream" path="res://video/event/stream/event21.ogv" id="3"]
 [ext_resource type="AudioStream" uid="uid://6npltv6hfi0q" path="res://video/event/en/event21.ogg" id="4"]
 
 [node name="Event" instance=ExtResource("1")]
@@ -81,5 +80,5 @@ event01_69	250.3	2.5	-1	-1
 event01_70	253.7	0.1	-1	-1
 event01_71	256.4	2.4	-1	-1"
 
-[node name="Video" parent="." index="0"]
-stream = ExtResource("3")
+[node name="Video" parent="." index="1"]
+videoFilePath = "res://video/event/stream/event21.ogv"

--- a/Project/video/event/scene/Event22.tscn
+++ b/Project/video/event/scene/Event22.tscn
@@ -1,8 +1,7 @@
-[gd_scene load_steps=5 format=3 uid="uid://e0rqf7u71tq"]
+[gd_scene load_steps=4 format=3 uid="uid://e0rqf7u71tq"]
 
 [ext_resource type="PackedScene" uid="uid://ct1tmuno23lj2" path="res://video/Event.tscn" id="1"]
 [ext_resource type="AudioStream" uid="uid://bycjdgfgleacq" path="res://video/event/ja/event22.ogg" id="2"]
-[ext_resource type="VideoStream" path="res://video/event/stream/event22.ogv" id="3"]
 [ext_resource type="AudioStream" uid="uid://bgxaie48emb67" path="res://video/event/en/event22.ogg" id="4"]
 
 [node name="Event" instance=ExtResource("1")]
@@ -81,5 +80,5 @@ event01_69	250.3	2.5	-1	-1
 event01_70	253.7	0.1	-1	-1
 event01_71	256.4	2.4	-1	-1"
 
-[node name="Video" parent="." index="0"]
-stream = ExtResource("3")
+[node name="Video" parent="." index="1"]
+videoFilePath = "res://video/event/stream/event22.ogv"

--- a/Project/video/event/scene/Event23.tscn
+++ b/Project/video/event/scene/Event23.tscn
@@ -1,8 +1,7 @@
-[gd_scene load_steps=5 format=3 uid="uid://bw8bcw0yu8cj5"]
+[gd_scene load_steps=4 format=3 uid="uid://bw8bcw0yu8cj5"]
 
 [ext_resource type="PackedScene" uid="uid://ct1tmuno23lj2" path="res://video/Event.tscn" id="1"]
 [ext_resource type="AudioStream" uid="uid://bki1x6u05afdf" path="res://video/event/ja/event23.ogg" id="2"]
-[ext_resource type="VideoStream" path="res://video/event/stream/event23.ogv" id="3"]
 [ext_resource type="AudioStream" uid="uid://m75v4b2urkhx" path="res://video/event/en/event23.ogg" id="4"]
 
 [node name="Event" instance=ExtResource("1")]
@@ -81,5 +80,5 @@ event01_69	250.3	2.5	-1	-1
 event01_70	253.7	0.1	-1	-1
 event01_71	256.4	2.4	-1	-1"
 
-[node name="Video" parent="." index="0"]
-stream = ExtResource("3")
+[node name="Video" parent="." index="1"]
+videoFilePath = "res://video/event/stream/event23.ogv"

--- a/Project/video/event/scene/Event24.tscn
+++ b/Project/video/event/scene/Event24.tscn
@@ -1,8 +1,7 @@
-[gd_scene load_steps=5 format=3 uid="uid://7vin6rxvpu3k"]
+[gd_scene load_steps=4 format=3 uid="uid://7vin6rxvpu3k"]
 
 [ext_resource type="PackedScene" uid="uid://ct1tmuno23lj2" path="res://video/Event.tscn" id="1"]
 [ext_resource type="AudioStream" uid="uid://dissxt83psaht" path="res://video/event/ja/event24.ogg" id="2"]
-[ext_resource type="VideoStream" path="res://video/event/stream/event24.ogv" id="3"]
 [ext_resource type="AudioStream" uid="uid://87ohkuxsqtdx" path="res://video/event/en/event24.ogg" id="4"]
 
 [node name="Event" instance=ExtResource("1")]
@@ -81,5 +80,5 @@ event01_69	250.3	2.5	-1	-1
 event01_70	253.7	0.1	-1	-1
 event01_71	256.4	2.4	-1	-1"
 
-[node name="Video" parent="." index="0"]
-stream = ExtResource("3")
+[node name="Video" parent="." index="1"]
+videoFilePath = "res://video/event/stream/event24.ogv"

--- a/Project/video/event/scene/Event25.tscn
+++ b/Project/video/event/scene/Event25.tscn
@@ -1,8 +1,7 @@
-[gd_scene load_steps=5 format=3 uid="uid://in25iq3vm6v8"]
+[gd_scene load_steps=4 format=3 uid="uid://in25iq3vm6v8"]
 
 [ext_resource type="PackedScene" uid="uid://ct1tmuno23lj2" path="res://video/Event.tscn" id="1"]
 [ext_resource type="AudioStream" uid="uid://c23f1hmc5xp0h" path="res://video/event/ja/event25.ogg" id="2"]
-[ext_resource type="VideoStream" path="res://video/event/stream/event25.ogv" id="3"]
 [ext_resource type="AudioStream" uid="uid://53mvur50ew17" path="res://video/event/en/event25.ogg" id="4"]
 
 [node name="Event" instance=ExtResource("1")]
@@ -81,5 +80,5 @@ event01_69	250.3	2.5	-1	-1
 event01_70	253.7	0.1	-1	-1
 event01_71	256.4	2.4	-1	-1"
 
-[node name="Video" parent="." index="0"]
-stream = ExtResource("3")
+[node name="Video" parent="." index="1"]
+videoFilePath = "res://video/event/stream/event25.ogv"

--- a/Project/video/event/scene/Event26.tscn
+++ b/Project/video/event/scene/Event26.tscn
@@ -1,8 +1,7 @@
-[gd_scene load_steps=5 format=3 uid="uid://bm733pf3gu2cx"]
+[gd_scene load_steps=4 format=3 uid="uid://bm733pf3gu2cx"]
 
 [ext_resource type="PackedScene" uid="uid://ct1tmuno23lj2" path="res://video/Event.tscn" id="1"]
 [ext_resource type="AudioStream" uid="uid://dbu42uomarb1b" path="res://video/event/ja/event26.ogg" id="2"]
-[ext_resource type="VideoStream" path="res://video/event/stream/event26.ogv" id="3"]
 [ext_resource type="AudioStream" uid="uid://da6dov3bix77q" path="res://video/event/en/event26.ogg" id="4"]
 
 [node name="Event" instance=ExtResource("1")]
@@ -81,5 +80,5 @@ event01_69	250.3	2.5	-1	-1
 event01_70	253.7	0.1	-1	-1
 event01_71	256.4	2.4	-1	-1"
 
-[node name="Video" parent="." index="0"]
-stream = ExtResource("3")
+[node name="Video" parent="." index="1"]
+videoFilePath = "res://video/event/stream/event26.ogv"

--- a/Project/video/event/scene/Event27.tscn
+++ b/Project/video/event/scene/Event27.tscn
@@ -1,8 +1,7 @@
-[gd_scene load_steps=5 format=3 uid="uid://qghmskcwhtra"]
+[gd_scene load_steps=4 format=3 uid="uid://qghmskcwhtra"]
 
 [ext_resource type="PackedScene" uid="uid://ct1tmuno23lj2" path="res://video/Event.tscn" id="1"]
 [ext_resource type="AudioStream" uid="uid://cev6sd0ysde0j" path="res://video/event/ja/event27.ogg" id="2"]
-[ext_resource type="VideoStream" path="res://video/event/stream/event27.ogv" id="3"]
 [ext_resource type="AudioStream" uid="uid://suml0ctoxhw2" path="res://video/event/en/event27.ogg" id="4"]
 
 [node name="Event" instance=ExtResource("1")]
@@ -81,5 +80,5 @@ event01_69	250.3	2.5	-1	-1
 event01_70	253.7	0.1	-1	-1
 event01_71	256.4	2.4	-1	-1"
 
-[node name="Video" parent="." index="0"]
-stream = ExtResource("3")
+[node name="Video" parent="." index="1"]
+videoFilePath = "res://video/event/stream/event27.ogv"

--- a/Project/video/event/scene/Event28.tscn
+++ b/Project/video/event/scene/Event28.tscn
@@ -1,8 +1,7 @@
-[gd_scene load_steps=5 format=3 uid="uid://b5dtx6fl6qsyu"]
+[gd_scene load_steps=4 format=3 uid="uid://b5dtx6fl6qsyu"]
 
 [ext_resource type="PackedScene" uid="uid://ct1tmuno23lj2" path="res://video/Event.tscn" id="1"]
 [ext_resource type="AudioStream" uid="uid://busgjnr5ixnc7" path="res://video/event/ja/event28.ogg" id="2"]
-[ext_resource type="VideoStream" path="res://video/event/stream/event28.ogv" id="3"]
 [ext_resource type="AudioStream" uid="uid://b1r00moiyrem8" path="res://video/event/en/event28.ogg" id="4"]
 
 [node name="Event" instance=ExtResource("1")]
@@ -81,5 +80,5 @@ event01_69	250.3	2.5	-1	-1
 event01_70	253.7	0.1	-1	-1
 event01_71	256.4	2.4	-1	-1"
 
-[node name="Video" parent="." index="0"]
-stream = ExtResource("3")
+[node name="Video" parent="." index="1"]
+videoFilePath = "res://video/event/stream/event28.ogv"

--- a/Project/video/event/scene/Event29.tscn
+++ b/Project/video/event/scene/Event29.tscn
@@ -1,7 +1,6 @@
-[gd_scene load_steps=5 format=3 uid="uid://bhtoebxw22yhe"]
+[gd_scene load_steps=4 format=3 uid="uid://bhtoebxw22yhe"]
 
 [ext_resource type="PackedScene" uid="uid://ct1tmuno23lj2" path="res://video/Event.tscn" id="1"]
-[ext_resource type="VideoStream" path="res://video/event/stream/event29.ogv" id="2"]
 [ext_resource type="AudioStream" uid="uid://b1dekpshojota" path="res://video/event/en/event29.ogg" id="3"]
 [ext_resource type="AudioStream" uid="uid://hdt3y0n4ej7s" path="res://video/event/ja/event29.ogg" id="4"]
 
@@ -9,5 +8,5 @@
 enAudio = ExtResource("3")
 jaAudio = ExtResource("4")
 
-[node name="Video" parent="." index="0"]
-stream = ExtResource("2")
+[node name="Video" parent="." index="1"]
+videoFilePath = "res://video/event/stream/event29.ogv"

--- a/Project/video/event/scene/Event3.tscn
+++ b/Project/video/event/scene/Event3.tscn
@@ -1,9 +1,8 @@
-[gd_scene load_steps=5 format=3 uid="uid://dndd4pm3ldfcd"]
+[gd_scene load_steps=4 format=3 uid="uid://dndd4pm3ldfcd"]
 
 [ext_resource type="PackedScene" uid="uid://ct1tmuno23lj2" path="res://video/Event.tscn" id="1"]
 [ext_resource type="AudioStream" uid="uid://bio8cpoahrbll" path="res://video/event/en/event3.ogg" id="2"]
 [ext_resource type="AudioStream" uid="uid://deai01p7xjjqs" path="res://video/event/ja/event3.ogg" id="3"]
-[ext_resource type="VideoStream" path="res://video/event/stream/event3.ogv" id="4"]
 
 [node name="Event" instance=ExtResource("1")]
 enAudio = ExtResource("2")
@@ -81,5 +80,5 @@ event01_69	250.3	2.5	-1	-1
 event01_70	253.7	0.1	-1	-1
 event01_71	256.4	2.4	-1	-1"
 
-[node name="Video" parent="." index="0"]
-stream = ExtResource("4")
+[node name="Video" parent="." index="1"]
+videoFilePath = "res://video/event/stream/event3.ogv"

--- a/Project/video/event/scene/Event30.tscn
+++ b/Project/video/event/scene/Event30.tscn
@@ -1,12 +1,11 @@
-[gd_scene load_steps=4 format=3 uid="uid://4hnt3wrv5etx"]
+[gd_scene load_steps=3 format=3 uid="uid://4hnt3wrv5etx"]
 
 [ext_resource type="PackedScene" uid="uid://ct1tmuno23lj2" path="res://video/Event.tscn" id="1"]
 [ext_resource type="AudioStream" uid="uid://dx83rjbiusq72" path="res://video/event/ending.ogg" id="2"]
-[ext_resource type="VideoStream" path="res://video/event/stream/event30.ogv" id="3"]
 
 [node name="Event" instance=ExtResource("1")]
 enAudio = ExtResource("2")
 jaAudio = ExtResource("2")
 
-[node name="Video" parent="." index="0"]
-stream = ExtResource("3")
+[node name="Video" parent="." index="1"]
+videoFilePath = "res://video/event/stream/event30.ogv"

--- a/Project/video/event/scene/Event4.tscn
+++ b/Project/video/event/scene/Event4.tscn
@@ -1,9 +1,8 @@
-[gd_scene load_steps=5 format=3 uid="uid://brqjhltdtvd2v"]
+[gd_scene load_steps=4 format=3 uid="uid://brqjhltdtvd2v"]
 
 [ext_resource type="PackedScene" uid="uid://ct1tmuno23lj2" path="res://video/Event.tscn" id="1"]
 [ext_resource type="AudioStream" uid="uid://ecf00vsdsogl" path="res://video/event/en/event4.ogg" id="2"]
 [ext_resource type="AudioStream" uid="uid://dv48qq5fg1qpw" path="res://video/event/ja/event4.ogg" id="3"]
-[ext_resource type="VideoStream" path="res://video/event/stream/event4.ogv" id="4"]
 
 [node name="Event" instance=ExtResource("1")]
 enAudio = ExtResource("2")
@@ -81,5 +80,5 @@ event01_69	250.3	2.5	-1	-1
 event01_70	253.7	0.1	-1	-1
 event01_71	256.4	2.4	-1	-1"
 
-[node name="Video" parent="." index="0"]
-stream = ExtResource("4")
+[node name="Video" parent="." index="1"]
+videoFilePath = "res://video/event/stream/event4.ogv"

--- a/Project/video/event/scene/Event5.tscn
+++ b/Project/video/event/scene/Event5.tscn
@@ -1,8 +1,7 @@
-[gd_scene load_steps=5 format=3 uid="uid://cjgbovcyy6834"]
+[gd_scene load_steps=4 format=3 uid="uid://cjgbovcyy6834"]
 
 [ext_resource type="PackedScene" uid="uid://ct1tmuno23lj2" path="res://video/Event.tscn" id="1"]
 [ext_resource type="AudioStream" uid="uid://cg167shxpmly4" path="res://video/event/ja/event5.ogg" id="2"]
-[ext_resource type="VideoStream" path="res://video/event/stream/event5.ogv" id="3"]
 [ext_resource type="AudioStream" uid="uid://b20vsf43mjk51" path="res://video/event/en/event5.ogg" id="4"]
 
 [node name="Event" instance=ExtResource("1")]
@@ -81,5 +80,5 @@ event01_69	250.3	2.5	-1	-1
 event01_70	253.7	0.1	-1	-1
 event01_71	256.4	2.4	-1	-1"
 
-[node name="Video" parent="." index="0"]
-stream = ExtResource("3")
+[node name="Video" parent="." index="1"]
+videoFilePath = "res://video/event/stream/event5.ogv"

--- a/Project/video/event/scene/Event6.tscn
+++ b/Project/video/event/scene/Event6.tscn
@@ -1,8 +1,7 @@
-[gd_scene load_steps=5 format=3 uid="uid://ckn8luxls7cs0"]
+[gd_scene load_steps=4 format=3 uid="uid://ckn8luxls7cs0"]
 
 [ext_resource type="PackedScene" uid="uid://ct1tmuno23lj2" path="res://video/Event.tscn" id="1"]
 [ext_resource type="AudioStream" uid="uid://dus0l7hopnqck" path="res://video/event/ja/event6.ogg" id="2"]
-[ext_resource type="VideoStream" path="res://video/event/stream/event6.ogv" id="3"]
 [ext_resource type="AudioStream" uid="uid://dfp1q3anj7l0r" path="res://video/event/en/event6.ogg" id="4"]
 
 [node name="Event" instance=ExtResource("1")]
@@ -81,5 +80,5 @@ event01_69	250.3	2.5	-1	-1
 event01_70	253.7	0.1	-1	-1
 event01_71	256.4	2.4	-1	-1"
 
-[node name="Video" parent="." index="0"]
-stream = ExtResource("3")
+[node name="Video" parent="." index="1"]
+videoFilePath = "res://video/event/stream/event6.ogv"

--- a/Project/video/event/scene/Event7.tscn
+++ b/Project/video/event/scene/Event7.tscn
@@ -1,8 +1,7 @@
-[gd_scene load_steps=5 format=3 uid="uid://dfdyoqaev4mnu"]
+[gd_scene load_steps=4 format=3 uid="uid://dfdyoqaev4mnu"]
 
 [ext_resource type="PackedScene" uid="uid://ct1tmuno23lj2" path="res://video/Event.tscn" id="1"]
 [ext_resource type="AudioStream" uid="uid://caaxsx0hl2y3u" path="res://video/event/ja/event7.ogg" id="2"]
-[ext_resource type="VideoStream" path="res://video/event/stream/event7.ogv" id="3"]
 [ext_resource type="AudioStream" uid="uid://beveq5pcj2hat" path="res://video/event/en/event7.ogg" id="4"]
 
 [node name="Event" instance=ExtResource("1")]
@@ -81,5 +80,5 @@ event01_69	250.3	2.5	-1	-1
 event01_70	253.7	0.1	-1	-1
 event01_71	256.4	2.4	-1	-1"
 
-[node name="Video" parent="." index="0"]
-stream = ExtResource("3")
+[node name="Video" parent="." index="1"]
+videoFilePath = "res://video/event/stream/event7.ogv"

--- a/Project/video/event/scene/Event8.tscn
+++ b/Project/video/event/scene/Event8.tscn
@@ -1,8 +1,7 @@
-[gd_scene load_steps=5 format=3 uid="uid://b2jb7h7jpb5k7"]
+[gd_scene load_steps=4 format=3 uid="uid://b2jb7h7jpb5k7"]
 
 [ext_resource type="PackedScene" uid="uid://ct1tmuno23lj2" path="res://video/Event.tscn" id="1"]
 [ext_resource type="AudioStream" uid="uid://bua06jopr61np" path="res://video/event/ja/event8.ogg" id="2"]
-[ext_resource type="VideoStream" path="res://video/event/stream/event8.ogv" id="3"]
 [ext_resource type="AudioStream" uid="uid://cicbh7qhaf1cy" path="res://video/event/en/event8.ogg" id="4"]
 
 [node name="Event" instance=ExtResource("1")]
@@ -81,5 +80,5 @@ event01_69	250.3	2.5	-1	-1
 event01_70	253.7	0.1	-1	-1
 event01_71	256.4	2.4	-1	-1"
 
-[node name="Video" parent="." index="0"]
-stream = ExtResource("3")
+[node name="Video" parent="." index="1"]
+videoFilePath = "res://video/event/stream/event8.ogv"

--- a/Project/video/event/scene/Event9.tscn
+++ b/Project/video/event/scene/Event9.tscn
@@ -1,7 +1,6 @@
-[gd_scene load_steps=5 format=3 uid="uid://cqese4le7krsl"]
+[gd_scene load_steps=4 format=3 uid="uid://cqese4le7krsl"]
 
 [ext_resource type="PackedScene" uid="uid://ct1tmuno23lj2" path="res://video/Event.tscn" id="1"]
-[ext_resource type="VideoStream" path="res://video/event/stream/event9.ogv" id="2"]
 [ext_resource type="AudioStream" uid="uid://bwsddceangs2o" path="res://video/event/ja/event9.ogg" id="3"]
 [ext_resource type="AudioStream" uid="uid://c711qkpgtkky6" path="res://video/event/en/event9.ogg" id="4"]
 
@@ -81,5 +80,5 @@ event01_69	250.3	2.5	-1	-1
 event01_70	253.7	0.1	-1	-1
 event01_71	256.4	2.4	-1	-1"
 
-[node name="Video" parent="." index="0"]
-stream = ExtResource("2")
+[node name="Video" parent="." index="1"]
+videoFilePath = "res://video/event/stream/event9.ogv"


### PR DESCRIPTION
Rework cutscenes to use file paths instead of references.
This allows collaborators to avoid downloading 800+ extra MBs.